### PR TITLE
Added logger to hide debug information from user

### DIFF
--- a/Logger/Logger.cs
+++ b/Logger/Logger.cs
@@ -1,0 +1,55 @@
+﻿namespace Logger;
+
+public static class Log
+{
+    // We go from Fatal up to Info because we first need to notify user about    //
+    // Fatal Errors and Errors, then Warnings and only then we should print info //
+    public enum Level
+    {
+        Disabled = 0,
+        FatalError = 1,
+        Error = 2,
+        Warning = 3,
+        Info = 4,
+    }
+    public static Level LoggerLevel { get; set; } = Level.Info; // Let the user choose the desired LogLevel before any engine stuff;
+
+    public static void Write(string message, Level requiredLogLevel = Level.Info, string end = "\n")
+    {
+        if (LoggerLevel >= requiredLogLevel)
+        {
+            Console.Write(message + end);
+        }
+    }
+    public static void InfoDateless(string message)
+    {
+        Write($"[INFO] {message}", Level.Info);
+    }
+    public static void Info(string message)
+    {
+        Write($"[{DateTime.Now:HH:mm:ss}] [INFO] {message}", Level.Info);
+    }
+    public static void Warning(string message)
+    {
+        Write($"[{DateTime.Now:HH:mm:ss}] [WARNING] {message}", Level.Warning);
+    }
+
+
+    public static void Error(string message, Exception? ex = null)
+    {
+        Write($"[{DateTime.Now:HH:mm:ss}] [ERROR] {message}", Level.Error);
+        if (ex != null)
+        {
+            Console.WriteLine($"Exception: {ex.GetType().Name} {ex.Message}");
+        }
+    }
+
+    public static void FatalError(string message, Exception? ex = null)
+    {
+        Write($"[{DateTime.Now:HH:mm:ss}] [FATAL_ERROR] {message}", Level.FatalError);
+        if (ex != null)
+        {
+            Console.WriteLine($"Exception: {ex.GetType().Name} {ex.Message}");
+        }
+    }
+}

--- a/Logger/Logger.csproj
+++ b/Logger/Logger.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/OwnAudio/Source/Engine/AudioEngineFactory.cs
+++ b/OwnAudio/Source/Engine/AudioEngineFactory.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using Ownaudio.Core;
 using OwnaudioNET.Exceptions;
+using Logger;
 
 namespace OwnaudioNET.Engine;
 
@@ -71,8 +72,8 @@ public static class AudioEngineFactory
         {
             if (nativeEngineException != null)
             {
-                Console.WriteLine($"NativeAudioEngine not available: {nativeEngineException.Message}");
-                Console.WriteLine("Falling back to platform-specific audio engine...");
+                Log.Error($"NativeAudioEngine not available: {nativeEngineException.Message}");
+                Log.Error("Falling back to platform-specific audio engine...");
             }
 
             try
@@ -89,11 +90,11 @@ public static class AudioEngineFactory
                 {
                     engine = CreatePulseAudioEngine();
                 }
-                else if(OperatingSystem.IsAndroid())
+                else if (OperatingSystem.IsAndroid())
                 {
                     engine = CreateAAudioEngine();
                 }
-                else if(OperatingSystem.IsIOS())
+                else if (OperatingSystem.IsIOS())
                 {
                     // iOS uses NativeAudioEngine via MiniAudio (CoreAudio backend)
                     // If we reach here, NativeAudioEngine initialization already failed above
@@ -583,7 +584,7 @@ public static class AudioEngineFactory
                 }
             }
         }
-        else if(OperatingSystem.IsAndroid())
+        else if (OperatingSystem.IsAndroid())
         {
             lock (_lock)
             {
@@ -605,7 +606,7 @@ public static class AudioEngineFactory
                 }
             }
         }
-        else if(OperatingSystem.IsIOS())
+        else if (OperatingSystem.IsIOS())
         {
             // iOS uses NativeAudioEngine (already checked above)
             return _nativeEngineType != null;

--- a/OwnAudio/Source/Features/Extensions/AudioReaderNote.cs
+++ b/OwnAudio/Source/Features/Extensions/AudioReaderNote.cs
@@ -1,5 +1,6 @@
 ﻿using Melanchall.DryWetMidi.Common;
 using Melanchall.DryWetMidi.Core;
+using Logger;
 using Microsoft.ML.OnnxRuntime;
 using System;
 using System.Collections.Generic;
@@ -353,7 +354,7 @@ public class ModelOutputHelper
             return new Tensor(null, null);
         }
 
-        #nullable disable
+#nullable disable
         var nOlap = Constants.N_OVERLAPPING_FRAMES / 2;
         var nOutputFramesOri = totalFrames * Constants.ANNOTATIONS_FPS / Constants.AUDIO_SAMPLE_RATE;
         var step = (int)t[0].Shape![t[0].Shape.Length - 1]; // Last dimension
@@ -361,7 +362,7 @@ public class ModelOutputHelper
         var shape0 = Math.Min(oriShape[0] * oriShape[1] - nOlap * 2, nOutputFramesOri);
         var rangeStart = nOlap * step;
         var rangeCount = (oriShape[1] - nOlap) * step - rangeStart;
-        #nullable restore
+#nullable restore
 
         // Determine shape and required memory
         var shape = new nint[] { shape0, step };
@@ -670,8 +671,8 @@ public static class MidiWriter
             DetectedTempo = bpm;
         }
 
-        Console.WriteLine($"Generating MIDI file with BPM: {bpm}");
-        Console.WriteLine($"Number of notes: {notes.Count}");
+        Log.Info($"Generating MIDI file with BPM: {bpm}");
+        Log.Info($"Number of notes: {notes.Count}");
 
         var midiFile = new MidiFile();  // The complete MIDI file
         var track = new TrackChunk();   // One track to hold all our notes
@@ -755,9 +756,9 @@ public static class MidiWriter
         }
         midiFile.Write(outputPath);
 
-        Console.WriteLine($"MIDI file saved: {outputPath}");
-        Console.WriteLine($"Time division: 480 ticks per quarter note");
-        Console.WriteLine($"Tempo: {bpm} BPM ({microsecondsPerQuarterNote} μs per quarter note)");
+        Log.Info($"MIDI file saved: {outputPath}");
+        Log.Info($"Time division: 480 ticks per quarter note");
+        Log.Info($"Tempo: {bpm} BPM ({microsecondsPerQuarterNote} μs per quarter note)");
     }
 
     /// <summary>
@@ -828,12 +829,12 @@ public static class MidiWriter
         {
             if (Math.Abs(detectedBpm - commonTempo) <= 3)
             {
-                //Console.WriteLine($"Tempo detection: {detectedBpm} BPM -> snapped to common tempo {commonTempo} BPM");
+                //Log.Info($"Tempo detection: {detectedBpm} BPM -> snapped to common tempo {commonTempo} BPM");
                 return commonTempo;
             }
         }
 
-        //Console.WriteLine($"Tempo detection: {detectedBpm} BPM (confidence: {beatCandidates[detectedBpm]} votes)");
+        //Log.Info($"Tempo detection: {detectedBpm} BPM (confidence: {beatCandidates[detectedBpm]} votes)");
         return detectedBpm;
     }
 }

--- a/OwnAudio/Source/Features/Matchering/Audiomatchering.cs
+++ b/OwnAudio/Source/Features/Matchering/Audiomatchering.cs
@@ -1,5 +1,6 @@
 using MathNet.Numerics.IntegralTransforms;
 using OwnaudioNET.Sources;
+using Logger;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -84,7 +85,7 @@ namespace OwnaudioNET.Features.Matchering
                     // 1. De-interleave
                     float[][] channelData = new float[channels][];
                     int samplesPerChannel = audioData.Length / channels;
-                    
+
                     for (int c = 0; c < channels; c++)
                         channelData[c] = new float[samplesPerChannel];
 
@@ -123,12 +124,12 @@ namespace OwnaudioNET.Features.Matchering
             List<SegmentAnalysis> filteredAnalyses = FilterOutlierSegments(segmentAnalyses);
 
             var spectrum = CalculateWeightedAverageSpectrum(filteredAnalyses);
-            
+
             // DEBUG: Print analyzed spectrum details
             Console.WriteLine($"\n=== ANALYZED SPECTRUM INFO ===");
             Console.WriteLine($"RMS: {spectrum.RMSLevel:F6}, Peak: {spectrum.PeakLevel:F6}");
             Console.WriteLine($"Loudness: {spectrum.Loudness:F1} dBFS, Dynamic Range: {spectrum.DynamicRange:F1} dB");
-            
+
             return spectrum;
         }
 
@@ -143,7 +144,7 @@ namespace OwnaudioNET.Features.Matchering
 
             int bands = spectra[0].FrequencyBands.Length;
             float[] avgSpectrum = new float[bands];
-            
+
             double sumRmsSquares = 0;
             double maxPeak = 0;
             // Loudness/DR will be recalculated from final RMS/Peak
@@ -151,7 +152,7 @@ namespace OwnaudioNET.Features.Matchering
             foreach (var s in spectra)
             {
                 for (int i = 0; i < bands; i++) avgSpectrum[i] += s.FrequencyBands[i];
-                
+
                 sumRmsSquares += s.RMSLevel * s.RMSLevel;
                 maxPeak = Math.Max(maxPeak, s.PeakLevel);
             }
@@ -164,7 +165,7 @@ namespace OwnaudioNET.Features.Matchering
             // Proper RMS Averaging (Root Mean Square of the RMS values)
             float finalRMS = (float)Math.Sqrt(sumRmsSquares / spectra.Count);
             float finalPeak = (float)maxPeak;
-            
+
             // Recalculate derived metrics
             float finalLoudness = 20 * (float)Math.Log10(Math.Max(finalRMS, 1e-10f));
             float finalDR = 20 * (float)Math.Log10(finalPeak / Math.Max(finalRMS, 1e-10f));

--- a/OwnAudio/Source/Features/Matchering/Audiomatchering.dynamics.cs
+++ b/OwnAudio/Source/Features/Matchering/Audiomatchering.dynamics.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Logger;
 
 namespace OwnaudioNET.Features.Matchering
 {
@@ -25,15 +26,15 @@ namespace OwnaudioNET.Features.Matchering
         {
             float sourceCrest = 20 * (float)Math.Log10(source.PeakLevel / Math.Max(source.RMSLevel, 1e-10f));
             float targetCrest = 20 * (float)Math.Log10(target.PeakLevel / Math.Max(target.RMSLevel, 1e-10f));
-            
+
             // Calculate optimal target level based on Loudness (LUFS-like approach)
             // Target is usually the reference file's loudness
             float targetLoudnessDb = target.Loudness;
-            
+
             // Compressor Calculation
             // If Source is more dynamic (higher crest) than Target, we need compression
             float crestDiff = sourceCrest - targetCrest;
-            
+
             float compThreshold = -12.0f;
             float compRatio = 1.0f;
 
@@ -42,11 +43,11 @@ namespace OwnaudioNET.Features.Matchering
                 // Source is too dynamic - apply compression
                 // Ratio scales with the crest difference
                 compRatio = 1.5f + (crestDiff * 0.5f); // e.g., 6dB diff -> 1.5 + 3 = 4.5 ratio
-                
+
                 // Threshold needs to be low enough to catch the peaks
                 // Approximately "Peak - CrestDiff" relative to full scale, but safer to use relative to RMS
                 // Threshold approx RMS + stable headroom
-                compThreshold = source.Loudness + (sourceCrest - crestDiff) * 0.5f; 
+                compThreshold = source.Loudness + (sourceCrest - crestDiff) * 0.5f;
             }
             else
             {
@@ -57,10 +58,10 @@ namespace OwnaudioNET.Features.Matchering
 
             // Safety clamps
             compRatio = Math.Clamp(compRatio, 1.0f, 10.0f);
-            compThreshold = Math.Clamp(compThreshold, -30.0f, -2.0f); 
+            compThreshold = Math.Clamp(compThreshold, -30.0f, -2.0f);
 
-            Console.WriteLine($"Dynamics Match: Source Crest {sourceCrest:F1}dB vs Target {targetCrest:F1}dB");
-            Console.WriteLine($"Calculated Compressor: Thresh {compThreshold:F1}dB, Ratio {compRatio:F1}:1");
+            Log.Info($"Dynamics Match: Source Crest {sourceCrest:F1}dB vs Target {targetCrest:F1}dB");
+            Log.Info($"Calculated Compressor: Thresh {compThreshold:F1}dB, Ratio {compRatio:F1}:1");
 
             // Store compressor settings in the (abused) DynamicAmpSettings or return a tuple
             // Since we only have DynamicAmpSettings type defined in the signature context of ProcessEQMatching,
@@ -79,10 +80,10 @@ namespace OwnaudioNET.Features.Matchering
             //
             // Let's assume for now I will use standard DynamicAmpSettings for the Amp, 
             // AND I will add a new method `CalculateCompressorSettings`.
-            
+
             // Let's stick to the original function for Amp, and I'll add a new one for Compressor. 
             // Retaining original logic for Amp but tuning it:
-            
+
             return new DynamicAmpSettings
             {
                 TargetLevel = targetLoudnessDb, // Match loudness directly
@@ -97,29 +98,29 @@ namespace OwnaudioNET.Features.Matchering
         /// </summary>
         private (float Threshold, float Ratio) CalculateCompressorSettings(AudioSpectrum source, AudioSpectrum target)
         {
-             float sourceCrest = 20 * (float)Math.Log10(source.PeakLevel / Math.Max(source.RMSLevel, 1e-10f));
-             float targetCrest = 20 * (float)Math.Log10(target.PeakLevel / Math.Max(target.RMSLevel, 1e-10f));
-             
-             float crestDiff = sourceCrest - targetCrest;
-             float ratio = 1.0f;
-             float threshold = -0.1f;
+            float sourceCrest = 20 * (float)Math.Log10(source.PeakLevel / Math.Max(source.RMSLevel, 1e-10f));
+            float targetCrest = 20 * (float)Math.Log10(target.PeakLevel / Math.Max(target.RMSLevel, 1e-10f));
 
-             if (crestDiff > 1.0f)
-             {
-                 // Reduced Ratio scaling (0.4f -> 0.25f) for more transparent gluing
-                 ratio = 1.0f + (crestDiff * 0.25f);
-                 // Threshold shoud be around the RMS level + some headroom
-                 // If signal is -12 RMS and we want to reduce crest by 3dB, threshold should be lower.
-                 threshold = 20 * (float)Math.Log10(source.RMSLevel) + 3.0f; 
-             }
-             else
-             {
-                 // Glue compression
-                 ratio = 2.0f;
-                 threshold = 20 * (float)Math.Log10(source.PeakLevel) - 4.0f;
-             }
+            float crestDiff = sourceCrest - targetCrest;
+            float ratio = 1.0f;
+            float threshold = -0.1f;
 
-             return (Math.Clamp(threshold, -40f, -0.5f), Math.Clamp(ratio, 1.2f, 20.0f));
+            if (crestDiff > 1.0f)
+            {
+                // Reduced Ratio scaling (0.4f -> 0.25f) for more transparent gluing
+                ratio = 1.0f + (crestDiff * 0.25f);
+                // Threshold shoud be around the RMS level + some headroom
+                // If signal is -12 RMS and we want to reduce crest by 3dB, threshold should be lower.
+                threshold = 20 * (float)Math.Log10(source.RMSLevel) + 3.0f;
+            }
+            else
+            {
+                // Glue compression
+                ratio = 2.0f;
+                threshold = 20 * (float)Math.Log10(source.PeakLevel) - 4.0f;
+            }
+
+            return (Math.Clamp(threshold, -40f, -0.5f), Math.Clamp(ratio, 1.2f, 20.0f));
         }
 
         #endregion

--- a/OwnAudio/Source/Features/Matchering/Audiomatchering.qfactors.cs
+++ b/OwnAudio/Source/Features/Matchering/Audiomatchering.qfactors.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Logger;
 
 namespace OwnaudioNET.Features.Matchering;
 
@@ -50,7 +51,7 @@ partial class AudioAnalyzer
             qFactors[i] = Math.Max(2.5f, Math.Min(8.0f, qFactors[i]));
         }
 
-        Console.WriteLine("Calculated Q factors:");
+        Log.Info("Calculated Q factors:");
         var bandNames = new[] {
             "20Hz", "25Hz", "31Hz", "40Hz", "50Hz", "63Hz", "80Hz", "100Hz", "125Hz", "160Hz",
             "200Hz", "250Hz", "315Hz", "400Hz", "500Hz", "630Hz", "800Hz", "1kHz", "1.25kHz", "1.6kHz",
@@ -59,7 +60,7 @@ partial class AudioAnalyzer
 
         for (int i = 0; i < qFactors.Length; i++)
         {
-            Console.WriteLine($"{bandNames[i]}: Q={qFactors[i]:F2} (Gain: {eqAdjustments[i]:+0.1;-0.1}dB)");
+            Log.Info($"{bandNames[i]}: Q={qFactors[i]:F2} (Gain: {eqAdjustments[i]:+0.1;-0.1}dB)");
         }
 
         return qFactors;
@@ -92,9 +93,9 @@ partial class AudioAnalyzer
             <= 315f => 4.0f,     // Standard tracking
             <= 630f => 4.2f,
             <= 1250f => 4.3f,    // Ideal 1/3 octave Q
-            <= 4000f => 4.3f,    
+            <= 4000f => 4.3f,
             <= 10000f => 4.2f,   // Slightly wider for high frequency air
-            _ => 4.0f            
+            _ => 4.0f
         };
     }
 

--- a/OwnAudio/Source/OwnaudioNET.Mobile.csproj
+++ b/OwnAudio/Source/OwnaudioNET.Mobile.csproj
@@ -64,6 +64,11 @@
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <!-- Platform-independent logger -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\Logger\Logger.csproj" />
+  </ItemGroup>
+  
   <!-- Platform-specific project references with private assets (embedded in this assembly) -->
   <ItemGroup>
     <!-- Core (always included) -->

--- a/OwnAudio/Source/OwnaudioNET.csproj
+++ b/OwnAudio/Source/OwnaudioNET.csproj
@@ -52,6 +52,11 @@
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <!-- Platform-independent logger -->
+  <ItemGroup>
+  <ProjectReference Include="..\..\Logger\Logger.csproj" />
+  </ItemGroup>
+
   <!-- Platform-specific project references with private assets (embedded in this assembly) -->
   <ItemGroup>
     <!-- Core (always included) -->

--- a/OwnAudioEngine/Ownaudio.Android/AAudioEngine.cs
+++ b/OwnAudioEngine/Ownaudio.Android/AAudioEngine.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Ownaudio.Android.Interop;
 using Ownaudio.Core;
 using Ownaudio.Core.Common;
+using Logger;
 
 namespace Ownaudio.Android
 {
@@ -325,8 +326,8 @@ namespace Ownaudio.Android
                         int result = AAudioInterop.AAudioStream_requestStop(_outputStream);
                         if (result != AAudioInterop.AAUDIO_OK)
                         {
-                            Console.WriteLine(
-                                $"Warning: Failed to stop output stream: {AAudioInterop.GetErrorString(result)}");
+                            Log.Warning(
+                                $"Failed to stop output stream: {AAudioInterop.GetErrorString(result)}");
                         }
 
                         // Wait for stream to stop (with timeout)
@@ -344,8 +345,8 @@ namespace Ownaudio.Android
                         int result = AAudioInterop.AAudioStream_requestStop(_inputStream);
                         if (result != AAudioInterop.AAUDIO_OK)
                         {
-                            Console.WriteLine(
-                                $"Warning: Failed to stop input stream: {AAudioInterop.GetErrorString(result)}");
+                            Log.Warning(
+                                $"Failed to stop input stream: {AAudioInterop.GetErrorString(result)}");
                         }
 
                         // Wait for stream to stop (with timeout)
@@ -359,7 +360,7 @@ namespace Ownaudio.Android
                     // Clean up resources to prepare for potential restart
                     CleanupResources();
 
-                    Console.WriteLine("AAudio streams stopped and closed. Call Initialize() to restart.");
+                    Log.Info("AAudio streams stopped and closed. Call Initialize() to restart.");
 
                     return AAudioInterop.AAUDIO_OK;
                 }
@@ -597,8 +598,8 @@ namespace Ownaudio.Android
                 // CRITICAL: Check if device uses different sample rate than requested
                 if (deviceSampleRate != _requestedSampleRate)
                 {
-                    Console.WriteLine(
-                        $"WARNING: AAudio sample rate mismatch! Requested: {_requestedSampleRate} Hz, " +
+                    Log.Warning(
+                        $"AAudio sample rate mismatch! Requested: {_requestedSampleRate} Hz, " +
                         $"Device using: {deviceSampleRate} Hz. Enabling automatic resampling...");
 
                     // Create resampler to handle the mismatch
@@ -613,13 +614,13 @@ namespace Ownaudio.Android
                     int tempBufferSize = _outputResampler.CalculateOutputSize(maxFrames * _requestedChannels);
                     _resampleTempBuffer = new float[tempBufferSize];
 
-                    Console.WriteLine($"Resampler enabled: {_requestedSampleRate}Hz -> {deviceSampleRate}Hz");
+                    Log.Info($"Resampler enabled: {_requestedSampleRate}Hz -> {deviceSampleRate}Hz");
                 }
 
                 if (deviceChannels != _requestedChannels)
                 {
-                    Console.WriteLine(
-                        $"WARNING: AAudio channel count mismatch. Requested: {_requestedChannels}, " +
+                    Log.Warning(
+                        $"AAudio channel count mismatch. Requested: {_requestedChannels}, " +
                         $"Got: {deviceChannels}. Audio may sound incorrect.");
                 }
 
@@ -632,7 +633,7 @@ namespace Ownaudio.Android
                     _framesPerBuffer = framesPerBurst;
                 }
 
-                Console.WriteLine($"AAudio output stream created: {_actualSampleRate}Hz, {_actualChannels}ch, {_framesPerBuffer} frames/buffer");
+                Log.Info($"AAudio output stream created: {_actualSampleRate}Hz, {_actualChannels}ch, {_framesPerBuffer} frames/buffer");
 
                 return AAudioInterop.AAUDIO_OK;
             }
@@ -696,8 +697,8 @@ namespace Ownaudio.Android
                 // CRITICAL: Check if device uses different sample rate than requested
                 if (deviceSampleRate != _requestedSampleRate)
                 {
-                    Console.WriteLine(
-                        $"WARNING: AAudio input sample rate mismatch! Requested: {_requestedSampleRate} Hz, " +
+                    Log.Warning(
+                        $"AAudio input sample rate mismatch! Requested: {_requestedSampleRate} Hz, " +
                         $"Device using: {deviceSampleRate} Hz. Enabling automatic resampling...");
 
                     // Create resampler to handle the mismatch
@@ -713,13 +714,13 @@ namespace Ownaudio.Android
                     int tempBufferSize = _inputResampler.CalculateOutputSize(maxFrames * deviceChannels);
                     _inputResampleTempBuffer = new float[tempBufferSize];
 
-                    Console.WriteLine($"Input resampler enabled: {deviceSampleRate}Hz -> {_requestedSampleRate}Hz");
+                    Log.Info($"Input resampler enabled: {deviceSampleRate}Hz -> {_requestedSampleRate}Hz");
                 }
 
                 if (deviceChannels != _requestedChannels)
                 {
-                    Console.WriteLine(
-                        $"WARNING: AAudio input channel count mismatch. Requested: {_requestedChannels}, " +
+                    Log.Warning(
+                        $"AAudio input channel count mismatch. Requested: {_requestedChannels}, " +
                         $"Got: {deviceChannels}. Audio may sound incorrect.");
                 }
 
@@ -738,7 +739,7 @@ namespace Ownaudio.Android
                     _framesPerBuffer = framesPerBurst;
                 }
 
-                Console.WriteLine($"AAudio input stream created: {deviceSampleRate}Hz, {deviceChannels}ch, {_framesPerBuffer} frames/buffer");
+                Log.Info($"AAudio input stream created: {deviceSampleRate}Hz, {deviceChannels}ch, {_framesPerBuffer} frames/buffer");
 
                 return AAudioInterop.AAUDIO_OK;
             }
@@ -913,7 +914,7 @@ namespace Ownaudio.Android
         /// </summary>
         private void OutputErrorCallback(IntPtr stream, IntPtr userData, int error)
         {
-            Console.WriteLine($"AAudio output stream error: {AAudioInterop.GetErrorString(error)}");
+            Log.Error($"AAudio output stream error: {AAudioInterop.GetErrorString(error)}");
             _isActive = -1;
 
             // Notify listeners about device state change
@@ -935,7 +936,7 @@ namespace Ownaudio.Android
         /// </summary>
         private void InputErrorCallback(IntPtr stream, IntPtr userData, int error)
         {
-            Console.WriteLine($"AAudio input stream error: {AAudioInterop.GetErrorString(error)}");
+            Log.Error($"AAudio input stream error: {AAudioInterop.GetErrorString(error)}");
             _isActive = -1;
 
             // Notify listeners about device state change

--- a/OwnAudioEngine/Ownaudio.Android/Ownaudio.Android.csproj
+++ b/OwnAudioEngine/Ownaudio.Android/Ownaudio.Android.csproj
@@ -22,6 +22,11 @@
     <AndroidUseInterpreter>false</AndroidUseInterpreter>
   </PropertyGroup>
 
+  <!-- Platform-independent logger -->
+  <ItemGroup>
+  <ProjectReference Include="..\..\Logger\Logger.csproj" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <Optimize>true</Optimize>
     <DebugType>portable</DebugType>

--- a/OwnAudioEngine/Ownaudio.Core/AudioDecoderFactory.cs
+++ b/OwnAudioEngine/Ownaudio.Core/AudioDecoderFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using Logger;
 using System.IO;
 using System.Runtime.InteropServices;
 using Ownaudio.Core.Common;
@@ -80,7 +81,7 @@ public static class AudioDecoderFactory
                 var decoder = Activator.CreateInstance(decoderType, filePath, targetSampleRate, targetChannels) as IAudioDecoder;
                 if (decoder != null)
                 {
-                    Console.WriteLine($"Using MiniAudio decoder for {format} format (native)");
+                    Log.Info($"Using MiniAudio decoder for {format} format (native)");
                     return decoder;
                 }
             }
@@ -88,8 +89,8 @@ public static class AudioDecoderFactory
         catch (Exception ex)
         {
             // MiniAudio not available - fallback to managed decoders
-            Console.WriteLine($"MiniAudio decoder not available: {ex.Message}");
-            Console.WriteLine("Falling back to managed decoder...");
+            Log.Error($"MiniAudio decoder not available: {ex.Message}");
+            Log.Info("Falling back to managed decoder...");
         }
 
         // FALLBACK: Use managed decoders
@@ -252,7 +253,7 @@ public static class AudioDecoderFactory
                 var decoder = Activator.CreateInstance(decoderType, filePath, targetSampleRate, targetChannels) as IAudioDecoder;
                 if (decoder != null)
                 {
-                    Console.WriteLine("Using MiniAudio decoder (native)");
+                    Log.Info("Using MiniAudio decoder (native)");
                     return decoder;
                 }
             }
@@ -260,8 +261,8 @@ public static class AudioDecoderFactory
         catch (Exception ex)
         {
             // MiniAudio not available - fallback to platform-specific or managed
-            Console.WriteLine($"MiniAudio decoder not available: {ex.Message}");
-            Console.WriteLine("Falling back to platform-specific decoder...");
+            Log.Error($"MiniAudio decoder not available: {ex.Message}");
+            Log.Error("Falling back to platform-specific decoder...");
         }
 
         // FALLBACK 1: Platform-specific decoders

--- a/OwnAudioEngine/Ownaudio.Core/Ownaudio.Core.csproj
+++ b/OwnAudioEngine/Ownaudio.Core/Ownaudio.Core.csproj
@@ -30,6 +30,11 @@
     <DefineConstants Condition="$(TargetFramework.Contains('ios'))">$(DefineConstants);IOS</DefineConstants>
   </PropertyGroup>
 
+  <!-- Platform-independent logger -->
+  <ItemGroup>
+  <ProjectReference Include="..\..\Logger\Logger.csproj" />
+  </ItemGroup>
+
   <!-- Android-specific settings -->
   <PropertyGroup Condition="$(TargetFramework.Contains('android'))">
     <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>

--- a/OwnAudioEngine/Ownaudio.Linux/PulseAudioEngine.cs
+++ b/OwnAudioEngine/Ownaudio.Linux/PulseAudioEngine.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Ownaudio.Core;
 using Ownaudio.Core.Common;
 using Ownaudio.Linux.Interop;
+using Logger;
 using static Ownaudio.Linux.Interop.PulseAudioInterop;
 
 namespace Ownaudio.Linux
@@ -333,11 +334,11 @@ namespace Ownaudio.Linux
                     unsafe
                     {
                         pa_sample_spec* actualSpec = (pa_sample_spec*)specPtr;
-                        // Console.WriteLine($"[PulseAudio] Requested sample rate: {config.SampleRate} Hz");
-                        // Console.WriteLine($"[PulseAudio] Actual stream sample rate: {actualSpec->rate} Hz");
+                        // Log.Info($"[PulseAudio] Requested sample rate: {config.SampleRate} Hz");
+                        // Log.Info($"[PulseAudio] Actual stream sample rate: {actualSpec->rate} Hz");
                         // if (actualSpec->rate != config.SampleRate)
                         // {
-                        //     Console.WriteLine($"[PulseAudio] WARNING: Sample rate mismatch! This will cause tempo issues.");
+                        //     Log.Warning($"[PulseAudio] WARNING: Sample rate mismatch! This will cause tempo issues.");
                         // }
                     }
                 }
@@ -349,15 +350,15 @@ namespace Ownaudio.Linux
                     unsafe
                     {
                         pa_buffer_attr* actualAttr = (pa_buffer_attr*)bufferAttrPtr;
-                        Console.WriteLine($"[PulseAudio] Requested buffer attributes:");
-                        Console.WriteLine($"  - tlength (target latency): {bufferBytes} bytes ({bufferBytes / sizeof(float)} samples)");
-                        Console.WriteLine($"  - minreq (minimum request): {bufferBytes / 2} bytes ({bufferBytes / (2 * sizeof(float))} samples)");
-                        Console.WriteLine($"[PulseAudio] Negotiated buffer attributes:");
-                        Console.WriteLine($"  - maxlength: {actualAttr->maxlength} bytes ({actualAttr->maxlength / sizeof(float)} samples)");
-                        Console.WriteLine($"  - tlength: {actualAttr->tlength} bytes ({actualAttr->tlength / sizeof(float)} samples)");
-                        Console.WriteLine($"  - prebuf: {actualAttr->prebuf} bytes ({actualAttr->prebuf / sizeof(float)} samples)");
-                        Console.WriteLine($"  - minreq: {actualAttr->minreq} bytes ({actualAttr->minreq / sizeof(float)} samples)");
-                        Console.WriteLine($"  - fragsize: {actualAttr->fragsize} bytes ({actualAttr->fragsize / sizeof(float)} samples)");
+                        Log.Info($"[PulseAudio] Requested buffer attributes:");
+                        Log.Info($"  - tlength (target latency): {bufferBytes} bytes ({bufferBytes / sizeof(float)} samples)");
+                        Log.Info($"  - minreq (minimum request): {bufferBytes / 2} bytes ({bufferBytes / (2 * sizeof(float))} samples)");
+                        Log.Info($"[PulseAudio] Negotiated buffer attributes:");
+                        Log.Info($"  - maxlength: {actualAttr->maxlength} bytes ({actualAttr->maxlength / sizeof(float)} samples)");
+                        Log.Info($"  - tlength: {actualAttr->tlength} bytes ({actualAttr->tlength / sizeof(float)} samples)");
+                        Log.Info($"  - prebuf: {actualAttr->prebuf} bytes ({actualAttr->prebuf / sizeof(float)} samples)");
+                        Log.Info($"  - minreq: {actualAttr->minreq} bytes ({actualAttr->minreq / sizeof(float)} samples)");
+                        Log.Info($"  - fragsize: {actualAttr->fragsize} bytes ({actualAttr->fragsize / sizeof(float)} samples)");
                     }
                 }
                 pa_threaded_mainloop_unlock(_mainLoop);
@@ -688,7 +689,7 @@ namespace Ownaudio.Linux
                             // Log timing every 100th callback only (reduced logging)
                             // if (currentCallback % 100 == 0)
                             // {
-                            //     Console.WriteLine($"[PA-Timing #{currentCallback}] Interval: {intervalMs:F2}ms (expected: {expectedIntervalMs:F2}ms, drift: {drift:F2}ms) | Requested: {samplesToWrite} samples | Ring: {_outputRing.AvailableRead}/{_outputRing.Capacity}");
+                            //     Log.Info($"[PA-Timing #{currentCallback}] Interval: {intervalMs:F2}ms (expected: {expectedIntervalMs:F2}ms, drift: {drift:F2}ms) | Requested: {samplesToWrite} samples | Ring: {_outputRing.AvailableRead}/{_outputRing.Capacity}");
                             // }
                         }
                     }
@@ -967,7 +968,7 @@ namespace Ownaudio.Linux
             {
                 if (_callbackCount == 0)
                 {
-                    //Console.WriteLine("[PA-Stats] No callbacks received yet");
+                    //Log.Info("[PA-Stats] No callbacks received yet");
                     return;
                 }
 

--- a/OwnAudioEngine/Ownaudio.Native/MiniAudio/MaBinding.cs
+++ b/OwnAudioEngine/Ownaudio.Native/MiniAudio/MaBinding.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using Ownaudio.Native.Utils;
+using Logger;
 
 namespace Ownaudio.Native.MiniAudio;
 
@@ -110,7 +111,7 @@ internal static partial class MaBinding
         InitializeBindings(loader);
     }
 
-    #nullable disable
+#nullable disable
     #region Context Operations
     public static unsafe MaResult ma_context_init(MaBackend[] backends, uint backendCount, IntPtr contextConfig, IntPtr context)
     {
@@ -604,7 +605,7 @@ internal static partial class MaBinding
         if (_maFree == null)
             throw new NotSupportedException("Memory free operation is not supported.");
 
-        if (string.IsNullOrEmpty(message)) Console.WriteLine(message);
+        if (string.IsNullOrEmpty(message)) Log.Write(message);
         _maFree(ptr, pUserData);
     }
 

--- a/Ownaudio.Desktop.slnf
+++ b/Ownaudio.Desktop.slnf
@@ -15,7 +15,7 @@
       "OwnAudio\\Examples\\Ownaudio.Example.Matching\\Ownaudio.Example.Matching.csproj",
       "OwnAudio\\Examples\\Ownaudio.Example.MultitrackPlayer\\Ownaudio.Example.MultitrackPlayer.csproj",
       "OwnAudio\\Examples\\Ownaudio.Example.VocalRemover\\Ownaudio.Example.Vocalremover.csproj",
-      "OwnAudio\\Source\\OwnaudioNET.csproj"
+      "OwnAudio\\Source\\OwnaudioNET.csproj",
     ]
   }
 }

--- a/Ownaudio.sln
+++ b/Ownaudio.sln
@@ -47,6 +47,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ownaudio.Native", "OwnAudio
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ownaudio.Example.MultitrackPlayer", "OwnAudio\Examples\Ownaudio.Example.MultitrackPlayer\Ownaudio.Example.MultitrackPlayer.csproj", "{263995E9-ED34-CB3A-4AD8-281CFDFC873F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Logger", "Logger\Logger.csproj", "{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -294,6 +296,18 @@ Global
 		{263995E9-ED34-CB3A-4AD8-281CFDFC873F}.Release|x64.Build.0 = Release|Any CPU
 		{263995E9-ED34-CB3A-4AD8-281CFDFC873F}.Release|x86.ActiveCfg = Release|Any CPU
 		{263995E9-ED34-CB3A-4AD8-281CFDFC873F}.Release|x86.Build.0 = Release|Any CPU
+		{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}.Debug|x64.Build.0 = Debug|Any CPU
+		{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}.Debug|x86.Build.0 = Debug|Any CPU
+		{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}.Release|x64.ActiveCfg = Release|Any CPU
+		{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}.Release|x64.Build.0 = Release|Any CPU
+		{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}.Release|x86.ActiveCfg = Release|Any CPU
+		{3005EDB1-6CFF-42D6-A9BB-C8D80FD8D1BA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Noticed that the repo contains a lot of Console.WriteLine's, and there was no logger level to disable the debug output. 

So I made a very simple logger. Manually replaced Console.WriteLine's with methods like Log.Warning(), Log.Info(), Log.Error() by corresponding severity of the debug information. 

In the end, it's just a static class. Very simple but it works and now the lib can be used in tui apps.

P.S: Some commit lines have been changed by Microsoft's Roslyn's autoformat. It doesn't affect the readability of the code, it just made the things in its own way.