### PR TITLE
fix: MiniAudio device selection ignored due to ma_device_config layout mismatch

### DIFF
--- a/OwnAudioEngine/Ownaudio.Native/MiniAudio/MaBinding.Delegates.cs
+++ b/OwnAudioEngine/Ownaudio.Native/MiniAudio/MaBinding.Delegates.cs
@@ -258,8 +258,9 @@ internal static unsafe partial class MaBinding
     /// <summary>
     /// Function pointer to the native ma_resampler_config_init function.
     /// Initializes resampler settings structure with default parameters.
+    /// Native signature: ma_resampler_config_init(format, channels, sampleRateIn, sampleRateOut, algorithm).
     /// </summary>
-    private static delegate* unmanaged[Cdecl]<MaFormat, MaFormat, uint, uint, uint, uint, MaResampleAlgorithm, MaResamplerConfig> _resamplerConfigInit;
+    private static delegate* unmanaged[Cdecl]<MaFormat, uint, uint, uint, MaResampleAlgorithm, MaResamplerConfig> _resamplerConfigInit;
 
     /// <summary>
     /// Function pointer to the native ma_free function.

--- a/OwnAudioEngine/Ownaudio.Native/MiniAudio/MaBinding.Enums.cs
+++ b/OwnAudioEngine/Ownaudio.Native/MiniAudio/MaBinding.Enums.cs
@@ -393,35 +393,15 @@ internal static partial class MaBinding
     }
 
     /// <summary>
-    /// Resampler algorithm types
+    /// Resampler algorithm types (matches miniaudio 0.11's <c>ma_resample_algorithm</c>,
+    /// which only defines linear and custom — the 0.10-era sinc algorithm was removed).
     /// </summary>
     public enum MaResampleAlgorithm
     {
         /// <summary>Linear interpolation. Fast but lower quality.</summary>
         Linear = 0,
-        /// <summary>Sinc interpolation. Slower but better quality.</summary>
-        Sinc,
         /// <summary>Custom/extensible algorithm.</summary>
         Custom
-    }
-
-    /// <summary>
-    /// Sinc resampler window function types
-    /// </summary>
-    public enum MaSincResamplerWindowFunction
-    {
-        /// <summary>Rectangular window (no windowing).</summary>
-        Rectangular = 0,
-        /// <summary>Hann window.</summary>
-        Hann,
-        /// <summary>Hamming window.</summary>
-        Hamming,
-        /// <summary>Blackman window.</summary>
-        Blackman,
-        /// <summary>Blackman-Harris window.</summary>
-        BlackmanHarris,
-        /// <summary>Blackman-Nuttall window.</summary>
-        BlackmanNuttall
     }
 
     /// <summary>

--- a/OwnAudioEngine/Ownaudio.Native/MiniAudio/MaBinding.Structs.cs
+++ b/OwnAudioEngine/Ownaudio.Native/MiniAudio/MaBinding.Structs.cs
@@ -620,8 +620,17 @@ internal static partial class MaBinding
     }
 
     /// <summary>
-    /// Field representing struct.
+    /// Mirror of miniaudio 0.11's <c>ma_resampler_config</c>. Layout must match the native struct
+    /// exactly (48 bytes on 64-bit): after <c>algorithm</c> come the two custom-backend pointers,
+    /// then the <c>linear</c> options.
     /// </summary>
+    /// <remarks>
+    /// This previously used the miniaudio 0.10 shape (a single allocation-callbacks pointer plus a
+    /// <c>sinc</c> config that no longer exists in 0.11), which made the struct 64 bytes and shifted
+    /// every subsequent <see cref="MaDeviceConfig"/> field by 16 bytes — most importantly
+    /// <c>playback.pDeviceID</c> and <c>capture.pDeviceID</c>, so explicit device selection was
+    /// silently ignored and the default device was always opened.
+    /// </remarks>
     [StructLayout(LayoutKind.Sequential)]
     public struct MaResamplerConfig
     {
@@ -651,19 +660,19 @@ internal static partial class MaBinding
         public MaResampleAlgorithm algorithm;
 
         /// <summary>
-        /// Field representing IntPtr.
+        /// Pointer to a custom resampling backend vtable (<c>ma_resampling_backend_vtable*</c>), or zero.
         /// </summary>
-        public IntPtr pAllocationCallbacks;
+        public IntPtr pBackendVTable;
+
+        /// <summary>
+        /// User data pointer passed to the custom resampling backend, or zero.
+        /// </summary>
+        public IntPtr pBackendUserData;
 
         /// <summary>
         /// Field representing MaResamplerLinearConfig.
         /// </summary>
         public MaResamplerLinearConfig linear;
-
-        /// <summary>
-        /// Field representing MaResamplerSincConfig.
-        /// </summary>
-        public MaResamplerSincConfig sinc;
     }
 
     /// <summary>
@@ -676,28 +685,6 @@ internal static partial class MaBinding
         /// Field representing uint.
         /// </summary>
         public uint lpfOrder;
-    }
-
-    /// <summary>
-    /// Field representing struct.
-    /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
-    public struct MaResamplerSincConfig
-    {
-        /// <summary>
-        /// Field representing MaSincResamplerWindowFunction.
-        /// </summary>
-        public MaSincResamplerWindowFunction windowFunction;
-
-        /// <summary>
-        /// Field representing double.
-        /// </summary>
-        public double windowWidth;
-
-        /// <summary>
-        /// Field representing double.
-        /// </summary>
-        public double transitionWidth;
     }
 
     /// <summary>
@@ -824,15 +811,20 @@ internal static partial class MaBinding
     }
 
     /// <summary>
-    /// Field representing struct.
+    /// Mirror of miniaudio's <c>ma_context</c>. Only the prefix through <see cref="backend"/> is
+    /// layout-accurate; the remainder intentionally over-sizes the struct so
+    /// <c>allocate_context</c> reserves at least <c>sizeof(ma_context)</c> (688 bytes native).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct MaContext
     {
         /// <summary>
-        /// Field representing IntPtr.
+        /// The native <c>ma_backend_callbacks</c> block: 13 function pointers (104 bytes on 64-bit).
+        /// Previously declared as a single IntPtr, which put <see cref="backend"/> at offset 8
+        /// instead of 104 and made the backend read return garbage.
         /// </summary>
-        public IntPtr callbacks;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 13)]
+        public IntPtr[] callbacks;
 
         /// <summary>
         /// Field representing MaBackend.

--- a/OwnAudioEngine/Ownaudio.Native/MiniAudio/MaBinding.cs
+++ b/OwnAudioEngine/Ownaudio.Native/MiniAudio/MaBinding.cs
@@ -134,7 +134,7 @@ internal static unsafe partial class MaBinding
                 loader.GetExport("ma_resampler_process_pcm_frames");
             _resamplerSetRate = (delegate* unmanaged[Cdecl]<IntPtr, uint, uint, MaResult>)
                 loader.GetExport("ma_resampler_set_rate");
-            _resamplerConfigInit = (delegate* unmanaged[Cdecl]<MaFormat, MaFormat, uint, uint, uint, uint, MaResampleAlgorithm, MaResamplerConfig>)
+            _resamplerConfigInit = (delegate* unmanaged[Cdecl]<MaFormat, uint, uint, uint, MaResampleAlgorithm, MaResamplerConfig>)
                 loader.GetExport("ma_resampler_config_init");
 
             _maMalloc = (delegate* unmanaged[Cdecl]<ulong, IntPtr, IntPtr>)
@@ -1140,7 +1140,8 @@ internal static unsafe partial class MaBinding
                 sampleRateIn = sampleRateIn,
                 sampleRateOut = sampleRateOut,
                 algorithm = algorithm,
-                pAllocationCallbacks = IntPtr.Zero
+                pBackendVTable = IntPtr.Zero,
+                pBackendUserData = IntPtr.Zero
             };
 
             if (algorithm == MaResampleAlgorithm.Linear)
@@ -1151,7 +1152,9 @@ internal static unsafe partial class MaBinding
             return config;
         }
 
-        return _resamplerConfigInit(formatIn, formatOut, channelsIn, channelsOut, sampleRateIn, sampleRateOut, algorithm);
+        // The native function takes a single format/channel pair; formatOut/channelsOut only
+        // participate in the managed fallback above (kept for signature compatibility).
+        return _resamplerConfigInit(formatIn, channelsIn, sampleRateIn, sampleRateOut, algorithm);
     }
 
     #endregion

--- a/OwnAudioEngine/Ownaudio.Native/NativeAudioEngine.Miniaudio.cs
+++ b/OwnAudioEngine/Ownaudio.Native/NativeAudioEngine.Miniaudio.cs
@@ -136,12 +136,6 @@ namespace Ownaudio.Native
                 return -1;
             }
 
-            // The managed MaResamplerConfig uses IntPtr (8 bytes) for allocationCallbacks,
-            // but the native ma_allocation_callbacks is 32 bytes (4 function pointers).
-            // This 8-byte shortfall shifts every field after 'resampling' in the native struct.
-            // Write playback/capture format and channels at their actual native C offsets.
-            PatchNativeDeviceConfig(configPtr, physicalOutChannels, _config.EnableInput, physicalInChannels);
-
             // Initialize device
             result = MaBinding.ma_device_init(_maContext, configPtr, _maDevice);
             MaBinding.ma_free(configPtr, IntPtr.Zero, "Device config cleanup");
@@ -162,7 +156,6 @@ namespace Ownaudio.Native
 
                 if (fallbackConfigPtr != IntPtr.Zero)
                 {
-                    PatchNativeDeviceConfig(fallbackConfigPtr, physicalOutChannels, _config.EnableInput, physicalInChannels);
                     result = MaBinding.ma_device_init(_maContext, fallbackConfigPtr, _maDevice);
                     MaBinding.ma_free(fallbackConfigPtr, IntPtr.Zero, "Fallback device config cleanup");
                 }
@@ -403,8 +396,6 @@ namespace Ownaudio.Native
                 return -1;
             }
 
-            PatchNativeDeviceConfig(configPtr, physicalOutChannels, _config.EnableInput, (uint)_physicalInputChannels);
-
             // Initialize device
             MaResult result = MaBinding.ma_device_init(_maContext, configPtr, _maDevice);
             MaBinding.ma_free(configPtr, IntPtr.Zero, "Device config cleanup");
@@ -434,7 +425,6 @@ namespace Ownaudio.Native
 
                 if (fallbackConfigPtr != IntPtr.Zero)
                 {
-                    PatchNativeDeviceConfig(fallbackConfigPtr, physicalOutChannels, _config.EnableInput, (uint)_physicalInputChannels);
                     result = MaBinding.ma_device_init(_maContext, fallbackConfigPtr, _maDevice);
                     MaBinding.ma_free(fallbackConfigPtr, IntPtr.Zero, "Fallback device config cleanup");
                 }
@@ -525,30 +515,6 @@ namespace Ownaudio.Native
                         Marshal.StructureToPtr(deviceInfo.Id, captureDeviceIdPtr, false);
                     }
                 }
-            }
-        }
-
-        /// <summary>
-        /// Patches a native ma_device_config buffer to write playback/capture format and channel
-        /// count at the correct native C offsets.
-        ///
-        /// The managed MaResamplerConfig is 16 bytes larger than the actual native
-        /// ma_resampler_config (48 bytes on 64-bit in MiniAudio 0.11.x).
-        /// Marshal.StructureToPtr therefore writes playback/capture fields at wrong positions,
-        /// so MiniAudio reads zeros for channels and defaults to device native values.
-        ///
-        /// Verified native field offsets (from ma_device_init disassembly on arm64):
-        ///   playback.pDeviceID @ 112   playback.format @ 120   playback.channels @ 124
-        ///   capture.pDeviceID  @ 152   capture.format  @ 160   capture.channels  @ 164
-        /// </summary>
-        private static void PatchNativeDeviceConfig(IntPtr configPtr, uint playbackChannels, bool hasCapture, uint captureChannels)
-        {
-            Marshal.WriteInt32(configPtr, 120, (int)MaFormat.F32);
-            Marshal.WriteInt32(configPtr, 124, (int)playbackChannels);
-            if (hasCapture)
-            {
-                Marshal.WriteInt32(configPtr, 160, (int)MaFormat.F32);
-                Marshal.WriteInt32(configPtr, 164, (int)captureChannels);
             }
         }
 

--- a/OwnAudioEngine/Ownaudio.Native/Ownaudio.Native.csproj
+++ b/OwnAudioEngine/Ownaudio.Native/Ownaudio.Native.csproj
@@ -53,6 +53,11 @@
     <ProjectReference Include="..\Ownaudio.Core\Ownaudio.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Lets the engine tests assert the MaBinding struct layouts against the native miniaudio ABI. -->
+    <InternalsVisibleTo Include="Ownaudio.Test.Engine" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <None Include="runtimes\win-x64\**\*.*">
       <Link>runtimes\win-x64\%(RecursiveDir)%(Filename)%(Extension)</Link>

--- a/OwnAudioTests/Ownaudio.EngineTest/MaBindingLayoutTests.cs
+++ b/OwnAudioTests/Ownaudio.EngineTest/MaBindingLayoutTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ownaudio.Native.MiniAudio;
+using System.Runtime.InteropServices;
+
+namespace Ownaudio.EngineTest
+{
+    /// <summary>
+    /// Guards the managed MaBinding struct mirrors against drift from the native miniaudio ABI.
+    ///
+    /// Expected values below are ground truth for miniaudio 0.11.24 on 64-bit platforms, produced
+    /// with a C program printing offsetof()/sizeof() against the official miniaudio.h (they are
+    /// identical on arm64 and x64 — the structs contain only 4-byte scalars and pointers).
+    ///
+    /// This matters because ma_device_config is built managed-side and blitted with
+    /// Marshal.StructureToPtr before ma_device_init reads it natively: any size mismatch in an
+    /// embedded struct shifts every following field. A 16-byte overshoot in MaResamplerConfig
+    /// (a leftover miniaudio 0.10 shape) previously displaced playback.pDeviceID and
+    /// capture.pDeviceID, so explicit device selection was silently ignored and the default
+    /// device always opened.
+    /// </summary>
+    [TestClass]
+    public class MaBindingLayoutTests
+    {
+        [TestMethod]
+        public void MaResamplerConfig_MatchesNativeLayout()
+        {
+            Assert.AreEqual(48, Marshal.SizeOf<MaBinding.MaResamplerConfig>());
+            Assert.AreEqual(16, (int)Marshal.OffsetOf<MaBinding.MaResamplerConfig>("algorithm"));
+            Assert.AreEqual(24, (int)Marshal.OffsetOf<MaBinding.MaResamplerConfig>("pBackendVTable"));
+            Assert.AreEqual(32, (int)Marshal.OffsetOf<MaBinding.MaResamplerConfig>("pBackendUserData"));
+            Assert.AreEqual(40, (int)Marshal.OffsetOf<MaBinding.MaResamplerConfig>("linear"));
+        }
+
+        [TestMethod]
+        public void MaDeviceConfig_MatchesNativeLayout()
+        {
+            Assert.AreEqual(296, Marshal.SizeOf<MaBinding.MaDeviceConfig>());
+            Assert.AreEqual(32, (int)Marshal.OffsetOf<MaBinding.MaDeviceConfig>("dataCallback"));
+            Assert.AreEqual(56, (int)Marshal.OffsetOf<MaBinding.MaDeviceConfig>("pUserData"));
+            Assert.AreEqual(64, (int)Marshal.OffsetOf<MaBinding.MaDeviceConfig>("resampling"));
+            Assert.AreEqual(112, (int)Marshal.OffsetOf<MaBinding.MaDeviceConfig>("playback"));
+            Assert.AreEqual(152, (int)Marshal.OffsetOf<MaBinding.MaDeviceConfig>("capture"));
+            Assert.AreEqual(192, (int)Marshal.OffsetOf<MaBinding.MaDeviceConfig>("wasapi"));
+            Assert.AreEqual(208, (int)Marshal.OffsetOf<MaBinding.MaDeviceConfig>("alsa"));
+            Assert.AreEqual(224, (int)Marshal.OffsetOf<MaBinding.MaDeviceConfig>("pulse"));
+            Assert.AreEqual(248, (int)Marshal.OffsetOf<MaBinding.MaDeviceConfig>("coreaudio"));
+            Assert.AreEqual(252, (int)Marshal.OffsetOf<MaBinding.MaDeviceConfig>("opensl"));
+            Assert.AreEqual(264, (int)Marshal.OffsetOf<MaBinding.MaDeviceConfig>("aaudio"));
+        }
+
+        [TestMethod]
+        public void MaDevicePlaybackAndCaptureConfig_MatchNativeLayout()
+        {
+            Assert.AreEqual(40, Marshal.SizeOf<MaBinding.MaDevicePlaybackConfig>());
+            Assert.AreEqual(40, Marshal.SizeOf<MaBinding.MaDeviceCaptureConfig>());
+            Assert.AreEqual(0, (int)Marshal.OffsetOf<MaBinding.MaDeviceCaptureConfig>("pDeviceID"));
+            Assert.AreEqual(8, (int)Marshal.OffsetOf<MaBinding.MaDeviceCaptureConfig>("format"));
+            Assert.AreEqual(12, (int)Marshal.OffsetOf<MaBinding.MaDeviceCaptureConfig>("channels"));
+            Assert.AreEqual(16, (int)Marshal.OffsetOf<MaBinding.MaDeviceCaptureConfig>("pChannelMap"));
+        }
+
+        [TestMethod]
+        public void MaDeviceInfo_MatchesNativeLayout()
+        {
+            Assert.AreEqual(1544, Marshal.SizeOf<MaBinding.MaDeviceInfo>());
+            Assert.AreEqual(256, (int)Marshal.OffsetOf<MaBinding.MaDeviceInfo>("nameBytes"));
+            Assert.AreEqual(512, (int)Marshal.OffsetOf<MaBinding.MaDeviceInfo>("isDefault"));
+        }
+
+        [TestMethod]
+        public void MaContext_BackendFieldMatchesNativeOffset()
+        {
+            // ma_context.backend sits after ma_backend_callbacks (13 function pointers = 104 bytes).
+            Assert.AreEqual(104, (int)Marshal.OffsetOf<MaBinding.MaContext>("backend"));
+            // The mirror only needs to be layout-accurate through 'backend', but must never be
+            // SMALLER than the native ma_context (688 bytes) because allocate_context sizes with it.
+            Assert.IsTrue(Marshal.SizeOf<MaBinding.MaContext>() >= 688);
+        }
+    }
+}


### PR DESCRIPTION

Fixes ModernMube/OwnAudioSharp#34.

On the MiniAudio backend, `SetInputDeviceByName`/`SetOutputDeviceByName` (and index variants) reported success but `ma_device_init` always opened the **system default** device.

### Root cause

`MaBinding.MaResamplerConfig` used the miniaudio **0.10** shape (single allocation-callbacks pointer + a `sinc` sub-config), making it 64 bytes where the bundled miniaudio **0.11.24**'s `ma_resampler_config` is 48. `ma_device_config_alloc` builds the device config managed-side and blits it with `Marshal.StructureToPtr`, so every field after `resampling` landed 16 bytes past its native offset — `capture.pDeviceID` was written onto native `capture.pChannelMap`, and native `capture.pDeviceID` read zeros → default device.

`PatchNativeDeviceConfig` was already writing `format`/`channels` at hardcoded native offsets to work around the same shift (its comment attributed the shift to `ma_allocation_callbacks` sizing, but the actual delta is the resampler-config shape); the device-id pointers were never patched, which is why selection specifically was broken while formats/channels worked.

### Changes

- **`MaResamplerConfig`** now matches `ma_resampler_config` (0.11) exactly: `pBackendVTable`, `pBackendUserData`, `linear`; the removed `sinc` config is deleted. This puts `MaDeviceConfig.playback` at offset 112 and `.capture` at 152 as native expects (total 296 bytes).
- **`MaResampleAlgorithm`** matches 0.11 (`linear`/`custom`; sinc was removed upstream in miniaudio).
- **`PatchNativeDeviceConfig` removed** — the blitted struct is now correct end-to-end, including the fallback-config paths.
- **`ma_resampler_config_init` binding arity fixed**: the native function takes `(format, channels, sampleRateIn, sampleRateOut, algorithm)`; the delegate declared 7 parameters. (The public managed helper keeps its signature; `formatOut`/`channelsOut` only feed the managed fallback.)
- **`MaContext.callbacks`** is now the 13-pointer `ma_backend_callbacks` block, so `MaContext.backend` reads from its real offset (104) instead of 8 — device enumeration previously labeled engines with a garbage backend value.
- **Regression tests** (`MaBindingLayoutTests`) assert the managed layouts against ground-truth `offsetof()`/`sizeof()` values from the official miniaudio 0.11.24 header (64-bit; identical on arm64/x64), plus `InternalsVisibleTo` for the engine test project.

### Verification

- New layout tests pass (fail against the previous mirrors).
- All 150 existing engine tests pass on macOS arm64.
- End-to-end on macOS/CoreAudio with 4 microphones attached: `AudioEngineWrapper.SetInputDeviceByName("Razer Kiyo Pro")` before `Start()` now binds the Razer — confirmed via `ma_device_get_name` on the device and `kAudioDevicePropertyDeviceIsRunningSomewhere` across all input devices. Before the fix, the same call returned `true` while the system-default microphone recorded.

### Notes / out of scope

- The managed fallbacks `allocate_decoder_config`/`ma_decoder_config_alloc` mirror `ma_decoder_config` inaccurately as well (native is 144 bytes; the mirror differs in `allocationCallbacks`, which is a 32-byte struct natively). They're dead code in practice because `MaDecoder` prefers the native `sf_allocate_decoder_config`, so they're left untouched here — happy to follow up if you'd like the same treatment.
- `_resamplerInit` also binds `ma_resampler_init` with a missing `ma_allocation_callbacks*` parameter; currently unused, left untouched for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
